### PR TITLE
don't install 'tests' package at top level

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author_email="robmarkcole@gmail.com",
     description="Unofficial python API for Sighthound",
     install_requires=REQUIRES,
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests','tests.*']),
     license="Apache License, Version 2.0",
     python_requires=">=3.6",
     classifiers=[


### PR DESCRIPTION
Hi Robin,

first, I hope you don't mind I included your component for [Home Assistant Gentoo Overlay](https://github.com/onkelbeh/HomeAssistantRepository). I do not use this component myself. But, during compilation test, the installation test script threw an error, because `setup.py` tries to install a package called `tests` at top level.

Build log: https://git.edevau.net/onkelbeh/HomeAssistantRepository/issues/163
I currently patched this for now at my repo (https://git.edevau.net/onkelbeh/HomeAssistantRepository/commit/3e965523a8cc62835d4ad2bf93f89ed8ff1bcd95).
Ebuild: https://github.com/onkelbeh/HomeAssistantRepository/tree/master/dev-python/simplehound

My change adds a generic exclusion to find_packages().

Thanks a lot.
 \B.